### PR TITLE
Avoid early short-circuit on switches

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -44,7 +44,8 @@ def cc(fn):
 def isswitchy(fn):
 	for h in fn.hlil.instructions:
 		if h.operation == HighLevelILOperation.HLIL_SWITCH:
-			return len(h.cases) > Settings().get_integer("tagteam.largeSwitch")
+			if len(h.cases) > Settings().get_integer("tagteam.largeSwitch"):
+				return True
 	return False
 
 def iscomplex(fn):


### PR DESCRIPTION
Didn't catch the stream live, but had to send a PR after yelling at my screen while watching the replay.

If there's a function with multiple switch operations, `isswitchy` will return the result of the first switch and not evaluate any subsequent switches. Not sure how often this might happen, but in the spirit of "tagteam", got your back :hand: 